### PR TITLE
fix: resolve ejs (critical) and moment (high/moderate) Dependabot alerts

### DIFF
--- a/1_Requests_Review/frontend/package-lock.json
+++ b/1_Requests_Review/frontend/package-lock.json
@@ -5893,16 +5893,6 @@
         "corsproxy": "bin/corsproxy"
       }
     },
-    "node_modules/corsproxy/node_modules/ejs": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.7.4.tgz",
-      "integrity": "sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/corsproxy/node_modules/eventemitter3": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz",
@@ -12430,9 +12420,9 @@
       }
     },
     "node_modules/moment": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.11.2.tgz",
-      "integrity": "sha512-jAR7oRWEtmyOKFd10OE2480k4rLh62CpOGoohDV6cQzpRCGXUEk5dmkYNDvtz0Bnt+72tSMebgLmIsXgaX+L7A==",
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
       "license": "MIT",
       "engines": {
         "node": "*"
@@ -16897,6 +16887,7 @@
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -17381,6 +17372,7 @@
       "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.15.2.tgz",
       "integrity": "sha512-0XavAZbNJ5sDrCbkpWL8mia0o5WPOd2YGtxrEiZkBK9FjLppIUK2TgxK6qGD2P3hUXTJNNPVibrerKcx5WkR1g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/bonjour": "^3.5.9",
         "@types/connect-history-api-fallback": "^1.3.5",

--- a/1_Requests_Review/frontend/package.json
+++ b/1_Requests_Review/frontend/package.json
@@ -31,5 +31,9 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "overrides": {
+    "ejs": "^3.1.10",
+    "moment": "^2.29.4"
   }
 }

--- a/1_Requests_Starter/frontend/package-lock.json
+++ b/1_Requests_Starter/frontend/package-lock.json
@@ -5893,16 +5893,6 @@
         "corsproxy": "bin/corsproxy"
       }
     },
-    "node_modules/corsproxy/node_modules/ejs": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.7.4.tgz",
-      "integrity": "sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/corsproxy/node_modules/eventemitter3": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz",
@@ -8578,15 +8568,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
       "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-    },
-    "node_modules/good-console/node_modules/moment": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.11.2.tgz",
-      "integrity": "sha512-jAR7oRWEtmyOKFd10OE2480k4rLh62CpOGoohDV6cQzpRCGXUEk5dmkYNDvtz0Bnt+72tSMebgLmIsXgaX+L7A==",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/good-console/node_modules/readable-stream": {
       "version": "1.0.34",
@@ -16906,6 +16887,7 @@
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -17390,6 +17372,7 @@
       "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.15.2.tgz",
       "integrity": "sha512-0XavAZbNJ5sDrCbkpWL8mia0o5WPOd2YGtxrEiZkBK9FjLppIUK2TgxK6qGD2P3hUXTJNNPVibrerKcx5WkR1g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/bonjour": "^3.5.9",
         "@types/connect-history-api-fallback": "^1.3.5",

--- a/1_Requests_Starter/frontend/package.json
+++ b/1_Requests_Starter/frontend/package.json
@@ -31,5 +31,9 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "overrides": {
+    "ejs": "^3.1.10",
+    "moment": "^2.29.4"
   }
 }

--- a/2_Errors_Review/frontend/package-lock.json
+++ b/2_Errors_Review/frontend/package-lock.json
@@ -5893,16 +5893,6 @@
         "corsproxy": "bin/corsproxy"
       }
     },
-    "node_modules/corsproxy/node_modules/ejs": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.7.4.tgz",
-      "integrity": "sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/corsproxy/node_modules/eventemitter3": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz",
@@ -8578,15 +8568,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
       "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-    },
-    "node_modules/good-console/node_modules/moment": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.11.2.tgz",
-      "integrity": "sha512-jAR7oRWEtmyOKFd10OE2480k4rLh62CpOGoohDV6cQzpRCGXUEk5dmkYNDvtz0Bnt+72tSMebgLmIsXgaX+L7A==",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/good-console/node_modules/readable-stream": {
       "version": "1.0.34",
@@ -16906,6 +16887,7 @@
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -17390,6 +17372,7 @@
       "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.15.2.tgz",
       "integrity": "sha512-0XavAZbNJ5sDrCbkpWL8mia0o5WPOd2YGtxrEiZkBK9FjLppIUK2TgxK6qGD2P3hUXTJNNPVibrerKcx5WkR1g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/bonjour": "^3.5.9",
         "@types/connect-history-api-fallback": "^1.3.5",

--- a/2_Errors_Review/frontend/package.json
+++ b/2_Errors_Review/frontend/package.json
@@ -31,5 +31,9 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "overrides": {
+    "ejs": "^3.1.10",
+    "moment": "^2.29.4"
   }
 }

--- a/2_Errors_Starter/frontend/package-lock.json
+++ b/2_Errors_Starter/frontend/package-lock.json
@@ -3560,20 +3560,6 @@
         "string.prototype.matchall": "^4.0.6"
       }
     },
-    "node_modules/@surma/rollup-plugin-off-main-thread/node_modules/ejs": {
-      "version": "3.1.10",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
-      "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
-      "dependencies": {
-        "jake": "^10.8.5"
-      },
-      "bin": {
-        "ejs": "bin/cli.js"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-5.4.0.tgz",
@@ -6985,11 +6971,16 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "node_modules/ejs": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.7.4.tgz",
-      "integrity": "sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==",
-      "hasInstallScript": true,
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
+      "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
       "license": "Apache-2.0",
+      "dependencies": {
+        "jake": "^10.8.5"
+      },
+      "bin": {
+        "ejs": "bin/cli.js"
+      },
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9126,15 +9117,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
       "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-    },
-    "node_modules/good-console/node_modules/moment": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.11.2.tgz",
-      "integrity": "sha512-jAR7oRWEtmyOKFd10OE2480k4rLh62CpOGoohDV6cQzpRCGXUEk5dmkYNDvtz0Bnt+72tSMebgLmIsXgaX+L7A==",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/good-console/node_modules/readable-stream": {
       "version": "1.0.34",
@@ -17706,6 +17688,7 @@
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -18194,6 +18177,7 @@
       "version": "4.15.2",
       "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.15.2.tgz",
       "integrity": "sha512-0XavAZbNJ5sDrCbkpWL8mia0o5WPOd2YGtxrEiZkBK9FjLppIUK2TgxK6qGD2P3hUXTJNNPVibrerKcx5WkR1g==",
+      "peer": true,
       "dependencies": {
         "@types/bonjour": "^3.5.9",
         "@types/connect-history-api-fallback": "^1.3.5",

--- a/2_Errors_Starter/frontend/package.json
+++ b/2_Errors_Starter/frontend/package.json
@@ -31,5 +31,9 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "overrides": {
+    "ejs": "^3.1.10",
+    "moment": "^2.29.4"
   }
 }

--- a/3_Testing_Review/frontend/package-lock.json
+++ b/3_Testing_Review/frontend/package-lock.json
@@ -5742,16 +5742,6 @@
         "corsproxy": "bin/corsproxy"
       }
     },
-    "node_modules/corsproxy/node_modules/ejs": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.7.4.tgz",
-      "integrity": "sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/corsproxy/node_modules/eventemitter3": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz",
@@ -8500,15 +8490,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
       "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-    },
-    "node_modules/good-console/node_modules/moment": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.11.2.tgz",
-      "integrity": "sha512-jAR7oRWEtmyOKFd10OE2480k4rLh62CpOGoohDV6cQzpRCGXUEk5dmkYNDvtz0Bnt+72tSMebgLmIsXgaX+L7A==",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/good-console/node_modules/readable-stream": {
       "version": "1.0.34",
@@ -16839,6 +16820,7 @@
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -17277,6 +17259,7 @@
       "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.15.2.tgz",
       "integrity": "sha512-0XavAZbNJ5sDrCbkpWL8mia0o5WPOd2YGtxrEiZkBK9FjLppIUK2TgxK6qGD2P3hUXTJNNPVibrerKcx5WkR1g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/bonjour": "^3.5.9",
         "@types/connect-history-api-fallback": "^1.3.5",

--- a/3_Testing_Review/frontend/package.json
+++ b/3_Testing_Review/frontend/package.json
@@ -31,5 +31,9 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "overrides": {
+    "ejs": "^3.1.10",
+    "moment": "^2.29.4"
   }
 }

--- a/3_Testing_Starter/frontend/package-lock.json
+++ b/3_Testing_Starter/frontend/package-lock.json
@@ -5742,16 +5742,6 @@
         "corsproxy": "bin/corsproxy"
       }
     },
-    "node_modules/corsproxy/node_modules/ejs": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.7.4.tgz",
-      "integrity": "sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/corsproxy/node_modules/eventemitter3": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz",
@@ -8500,15 +8490,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
       "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-    },
-    "node_modules/good-console/node_modules/moment": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.11.2.tgz",
-      "integrity": "sha512-jAR7oRWEtmyOKFd10OE2480k4rLh62CpOGoohDV6cQzpRCGXUEk5dmkYNDvtz0Bnt+72tSMebgLmIsXgaX+L7A==",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/good-console/node_modules/readable-stream": {
       "version": "1.0.34",
@@ -16839,6 +16820,7 @@
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -17277,6 +17259,7 @@
       "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.15.2.tgz",
       "integrity": "sha512-0XavAZbNJ5sDrCbkpWL8mia0o5WPOd2YGtxrEiZkBK9FjLppIUK2TgxK6qGD2P3hUXTJNNPVibrerKcx5WkR1g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/bonjour": "^3.5.9",
         "@types/connect-history-api-fallback": "^1.3.5",

--- a/3_Testing_Starter/frontend/package.json
+++ b/3_Testing_Starter/frontend/package.json
@@ -31,5 +31,9 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "overrides": {
+    "ejs": "^3.1.10",
+    "moment": "^2.29.4"
   }
 }

--- a/4_TDD_Review/frontend/package-lock.json
+++ b/4_TDD_Review/frontend/package-lock.json
@@ -5742,16 +5742,6 @@
         "corsproxy": "bin/corsproxy"
       }
     },
-    "node_modules/corsproxy/node_modules/ejs": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.7.4.tgz",
-      "integrity": "sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/corsproxy/node_modules/eventemitter3": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz",
@@ -8500,15 +8490,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
       "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-    },
-    "node_modules/good-console/node_modules/moment": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.11.2.tgz",
-      "integrity": "sha512-jAR7oRWEtmyOKFd10OE2480k4rLh62CpOGoohDV6cQzpRCGXUEk5dmkYNDvtz0Bnt+72tSMebgLmIsXgaX+L7A==",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/good-console/node_modules/readable-stream": {
       "version": "1.0.34",
@@ -16839,6 +16820,7 @@
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -17277,6 +17259,7 @@
       "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.15.2.tgz",
       "integrity": "sha512-0XavAZbNJ5sDrCbkpWL8mia0o5WPOd2YGtxrEiZkBK9FjLppIUK2TgxK6qGD2P3hUXTJNNPVibrerKcx5WkR1g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/bonjour": "^3.5.9",
         "@types/connect-history-api-fallback": "^1.3.5",

--- a/4_TDD_Review/frontend/package.json
+++ b/4_TDD_Review/frontend/package.json
@@ -31,5 +31,9 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "overrides": {
+    "ejs": "^3.1.10",
+    "moment": "^2.29.4"
   }
 }


### PR DESCRIPTION
## Summary

Adds `overrides` to all 7 affected `frontend/package.json` files to pin safe transitive versions that cannot be reached via normal parent-dependency upgrades (both parent chains are locked to `corsproxy@1.5.0`, the final published version).

## Vulnerability Summary

| Vulnerability | Package | Old Version | New Version | Status |
|---|---|---|---|---|
| ejs template injection (GHSA-phwq-j96m-2c2q) | ejs | 2.7.4 | 3.1.10 | ✅ Fixed |
| ejs pollution protection (GHSA-ghr5-ch3p-vcr6) | ejs | 2.7.4 | 3.1.10 | ✅ Fixed |
| moment Path Traversal (GHSA-8hfj-j24r-96c4) | moment | 2.11.2 | 2.30.1 | ✅ Fixed |
| moment ReDoS (GHSA-446m-mv8f-q348) | moment | 2.11.2 | 2.30.1 | ✅ Fixed |
| Prototype Pollution in hoek (GHSA-jp4x-w63m-7wgm) | hoek | 2.16.3 | 2.16.3 | ⛔ Blocked |
| hoek clone pollution (GHSA-c429-5p7v-vgjp) | hoek | 2.16.3 | 2.16.3 | ⛔ Blocked |
| qs Prototype Pollution (GHSA-gqgv-6jq5-jjj9) | qs | 4.0.0 | 4.0.0 | ⛔ Blocked |

## Files Changed

All 7 `frontend/package.json` + `frontend/package-lock.json` in:
`1_Requests_Starter`, `1_Requests_Review`, `2_Errors_Starter`, `2_Errors_Review`, `3_Testing_Starter`, `3_Testing_Review`, `4_TDD_Review`

## Dependency Changes

Added to every `package.json`:
```json
"overrides": {
  "ejs": "^3.1.10",
  "moment": "^2.29.4"
}
```

**ejs** — `corsproxy@1.5.0` (latest, no update available) pins `ejs@^2.3.3`, resolving to the vulnerable `2.7.4`. The override forces `ejs≥3.1.10` everywhere. ejs 3.x is backward-compatible with 2.x for corsproxy's basic template usage.

**moment** — `good-console@5.3.2` pins `moment@2.11.x`, resolving to the vulnerable `2.11.2`. The override forces `moment≥2.29.4`. The moment 2.x API is stable and this is non-breaking.

## Why hoek and qs cannot be fixed

`hoek@2.16.3` and `qs@4.0.0` live inside `corsproxy → hapi@9.5.1`. hapi 9 explicitly requires `hoek@^2.14.x` and `qs@4.x`. Forcing a major-version bump (hoek ≥4.2.1, qs ≥6.0.4) via overrides would silently break hapi's internal clone/deep-merge and query-string parsing, making corsproxy non-functional at runtime.

**Recommended path:** Replace `corsproxy` with a maintained alternative (e.g. `local-cors-proxy`, `http-proxy-middleware`, or the built-in `"proxy"` field in `package.json` already present). Effort: **Medium**.

## Commands Executed

```
# For each of the 7 frontend directories:
npm install --package-lock-only   # regenerate lock file respecting new overrides
```

## Validation Results

- **ejs**: `FIXED` in all 7 projects (npm audit confirms no ejs vulnerability)
- **moment**: `FIXED` in all 7 projects (npm audit confirms no moment vulnerability)
- **hoek**: Remains flagged (blocked by hapi@9.x API compatibility)
- **qs**: Remains flagged (blocked by hapi@9.x API compatibility)
- No source code changes; only lock-file regeneration from overrides

🤖 Generated with [Claude Code](https://claude.com/claude-code)