### PR TITLE
fix: Jinja2 3.1.6, Flask-Cors 6.0.0, @tootallnate/once 3.0.1

### DIFF
--- a/1_Requests_Review/frontend/package-lock.json
+++ b/1_Requests_Review/frontend/package-lock.json
@@ -3472,18 +3472,17 @@
       "license": "0BSD"
     },
     "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
-      "version": "0.5.10",
-      "resolved": "https://registry.npmjs.org/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.10.tgz",
-      "integrity": "sha512-j0Ya0hCFZPd4x40qLzbhGsh9TMtdb+CJQiso+WxLOPNasohq9cc5SNUcwsZaRH6++Xh91Xkm/xHCkuIiIu0LUA==",
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.17.tgz",
+      "integrity": "sha512-tXDyE1/jzFsHXjhRZQ3hMl0IVhYe5qula43LDWIhVfjp9G/nT5OQY5AORVOrkEGAUltBJOfOWeETbmhm6kHhuQ==",
+      "license": "MIT",
       "dependencies": {
-        "ansi-html-community": "^0.0.8",
-        "common-path-prefix": "^3.0.0",
+        "ansi-html": "^0.0.9",
         "core-js-pure": "^3.23.3",
         "error-stack-parser": "^2.0.6",
-        "find-up": "^5.0.0",
         "html-entities": "^2.1.0",
         "loader-utils": "^2.0.4",
-        "schema-utils": "^3.0.0",
+        "schema-utils": "^4.2.0",
         "source-map": "^0.7.3"
       },
       "engines": {
@@ -3493,9 +3492,9 @@
         "@types/webpack": "4.x || 5.x",
         "react-refresh": ">=0.10.0 <1.0.0",
         "sockjs-client": "^1.4.0",
-        "type-fest": ">=0.17.0 <4.0.0",
+        "type-fest": ">=0.17.0 <5.0.0",
         "webpack": ">=4.43.0 <6.0.0",
-        "webpack-dev-server": "3.x || 4.x",
+        "webpack-dev-server": "3.x || 4.x || 5.x",
         "webpack-hot-middleware": "2.x",
         "webpack-plugin-serve": "0.x || 1.x"
       },
@@ -3518,6 +3517,25 @@
         "webpack-plugin-serve": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@pmmmwh/react-refresh-webpack-plugin/node_modules/schema-utils": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
+      "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.9",
+        "ajv": "^8.9.0",
+        "ajv-formats": "^2.1.1",
+        "ajv-keywords": "^5.1.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/@rollup/plugin-babel": {
@@ -3839,11 +3857,12 @@
       }
     },
     "node_modules/@tootallnate/once": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
-      "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-3.0.1.tgz",
+      "integrity": "sha512-VyMVKRrpHTT8PnotUeV8L/mDaMwD5DaAKCFLP73zAqAtvF0FCqky+Ki7BYbFCYQmqFyTe9316Ed5zS70QUR9eg==",
+      "license": "MIT",
       "engines": {
-        "node": ">= 6"
+        "node": ">= 10"
       }
     },
     "node_modules/@types/babel__core": {
@@ -4695,6 +4714,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-html": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.9.tgz",
+      "integrity": "sha512-ozbS3LuenHVxNRh/wdnN16QapUHzauqSomAl1jwwJRRsGwFwtj644lIhxfWu0Fy0acCij2+AEgHvjscq3dlVXg==",
+      "engines": [
+        "node >= 0.8.0"
+      ],
+      "license": "Apache-2.0",
+      "bin": {
+        "ansi-html": "bin/ansi-html"
       }
     },
     "node_modules/ansi-html-community": {
@@ -5886,11 +5917,6 @@
       "engines": {
         "node": ">= 10"
       }
-    },
-    "node_modules/common-path-prefix": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/common-path-prefix/-/common-path-prefix-3.0.0.tgz",
-      "integrity": "sha512-QE33hToZseCH3jS0qN96O/bSh3kaw/h+Tq7ngyY9eWDUnTlTNUyqfqvCXioLe5Na5jFsL78ra/wuBU4iuEgd4w=="
     },
     "node_modules/common-tags": {
       "version": "1.8.2",

--- a/1_Requests_Review/frontend/package.json
+++ b/1_Requests_Review/frontend/package.json
@@ -35,6 +35,7 @@
     "nth-check": "^2.1.1",
     "serialize-javascript": "^7.0.3",
     "underscore": "^1.13.8",
-    "webpack-dev-server": "^5.2.5"
+    "webpack-dev-server": "^5.2.5",
+    "@tootallnate/once": "^3.0.1"
   }
 }

--- a/1_Requests_Starter/backend/requirements.txt
+++ b/1_Requests_Starter/backend/requirements.txt
@@ -1,7 +1,7 @@
 aniso8601==6.0.0
 Click==7.0
 Flask==2.2.5
-Flask-Cors==5.0.0
+Flask-Cors==6.0.0
 Flask-RESTful==0.3.7
 Flask-SQLAlchemy==2.4.0
 itsdangerous==1.1.0

--- a/1_Requests_Starter/frontend/package-lock.json
+++ b/1_Requests_Starter/frontend/package-lock.json
@@ -3472,18 +3472,17 @@
       "license": "0BSD"
     },
     "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
-      "version": "0.5.10",
-      "resolved": "https://registry.npmjs.org/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.10.tgz",
-      "integrity": "sha512-j0Ya0hCFZPd4x40qLzbhGsh9TMtdb+CJQiso+WxLOPNasohq9cc5SNUcwsZaRH6++Xh91Xkm/xHCkuIiIu0LUA==",
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.17.tgz",
+      "integrity": "sha512-tXDyE1/jzFsHXjhRZQ3hMl0IVhYe5qula43LDWIhVfjp9G/nT5OQY5AORVOrkEGAUltBJOfOWeETbmhm6kHhuQ==",
+      "license": "MIT",
       "dependencies": {
-        "ansi-html-community": "^0.0.8",
-        "common-path-prefix": "^3.0.0",
+        "ansi-html": "^0.0.9",
         "core-js-pure": "^3.23.3",
         "error-stack-parser": "^2.0.6",
-        "find-up": "^5.0.0",
         "html-entities": "^2.1.0",
         "loader-utils": "^2.0.4",
-        "schema-utils": "^3.0.0",
+        "schema-utils": "^4.2.0",
         "source-map": "^0.7.3"
       },
       "engines": {
@@ -3493,9 +3492,9 @@
         "@types/webpack": "4.x || 5.x",
         "react-refresh": ">=0.10.0 <1.0.0",
         "sockjs-client": "^1.4.0",
-        "type-fest": ">=0.17.0 <4.0.0",
+        "type-fest": ">=0.17.0 <5.0.0",
         "webpack": ">=4.43.0 <6.0.0",
-        "webpack-dev-server": "3.x || 4.x",
+        "webpack-dev-server": "3.x || 4.x || 5.x",
         "webpack-hot-middleware": "2.x",
         "webpack-plugin-serve": "0.x || 1.x"
       },
@@ -3518,6 +3517,25 @@
         "webpack-plugin-serve": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@pmmmwh/react-refresh-webpack-plugin/node_modules/schema-utils": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
+      "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.9",
+        "ajv": "^8.9.0",
+        "ajv-formats": "^2.1.1",
+        "ajv-keywords": "^5.1.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/@rollup/plugin-babel": {
@@ -3839,11 +3857,12 @@
       }
     },
     "node_modules/@tootallnate/once": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
-      "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-3.0.1.tgz",
+      "integrity": "sha512-VyMVKRrpHTT8PnotUeV8L/mDaMwD5DaAKCFLP73zAqAtvF0FCqky+Ki7BYbFCYQmqFyTe9316Ed5zS70QUR9eg==",
+      "license": "MIT",
       "engines": {
-        "node": ">= 6"
+        "node": ">= 10"
       }
     },
     "node_modules/@types/babel__core": {
@@ -4695,6 +4714,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-html": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.9.tgz",
+      "integrity": "sha512-ozbS3LuenHVxNRh/wdnN16QapUHzauqSomAl1jwwJRRsGwFwtj644lIhxfWu0Fy0acCij2+AEgHvjscq3dlVXg==",
+      "engines": [
+        "node >= 0.8.0"
+      ],
+      "license": "Apache-2.0",
+      "bin": {
+        "ansi-html": "bin/ansi-html"
       }
     },
     "node_modules/ansi-html-community": {
@@ -5886,11 +5917,6 @@
       "engines": {
         "node": ">= 10"
       }
-    },
-    "node_modules/common-path-prefix": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/common-path-prefix/-/common-path-prefix-3.0.0.tgz",
-      "integrity": "sha512-QE33hToZseCH3jS0qN96O/bSh3kaw/h+Tq7ngyY9eWDUnTlTNUyqfqvCXioLe5Na5jFsL78ra/wuBU4iuEgd4w=="
     },
     "node_modules/common-tags": {
       "version": "1.8.2",

--- a/1_Requests_Starter/frontend/package.json
+++ b/1_Requests_Starter/frontend/package.json
@@ -35,6 +35,7 @@
     "nth-check": "^2.1.1",
     "serialize-javascript": "^7.0.3",
     "underscore": "^1.13.8",
-    "webpack-dev-server": "^5.2.5"
+    "webpack-dev-server": "^5.2.5",
+    "@tootallnate/once": "^3.0.1"
   }
 }

--- a/2_Errors_Review/frontend/package-lock.json
+++ b/2_Errors_Review/frontend/package-lock.json
@@ -3472,18 +3472,17 @@
       "license": "0BSD"
     },
     "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
-      "version": "0.5.10",
-      "resolved": "https://registry.npmjs.org/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.10.tgz",
-      "integrity": "sha512-j0Ya0hCFZPd4x40qLzbhGsh9TMtdb+CJQiso+WxLOPNasohq9cc5SNUcwsZaRH6++Xh91Xkm/xHCkuIiIu0LUA==",
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.17.tgz",
+      "integrity": "sha512-tXDyE1/jzFsHXjhRZQ3hMl0IVhYe5qula43LDWIhVfjp9G/nT5OQY5AORVOrkEGAUltBJOfOWeETbmhm6kHhuQ==",
+      "license": "MIT",
       "dependencies": {
-        "ansi-html-community": "^0.0.8",
-        "common-path-prefix": "^3.0.0",
+        "ansi-html": "^0.0.9",
         "core-js-pure": "^3.23.3",
         "error-stack-parser": "^2.0.6",
-        "find-up": "^5.0.0",
         "html-entities": "^2.1.0",
         "loader-utils": "^2.0.4",
-        "schema-utils": "^3.0.0",
+        "schema-utils": "^4.2.0",
         "source-map": "^0.7.3"
       },
       "engines": {
@@ -3493,9 +3492,9 @@
         "@types/webpack": "4.x || 5.x",
         "react-refresh": ">=0.10.0 <1.0.0",
         "sockjs-client": "^1.4.0",
-        "type-fest": ">=0.17.0 <4.0.0",
+        "type-fest": ">=0.17.0 <5.0.0",
         "webpack": ">=4.43.0 <6.0.0",
-        "webpack-dev-server": "3.x || 4.x",
+        "webpack-dev-server": "3.x || 4.x || 5.x",
         "webpack-hot-middleware": "2.x",
         "webpack-plugin-serve": "0.x || 1.x"
       },
@@ -3518,6 +3517,25 @@
         "webpack-plugin-serve": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@pmmmwh/react-refresh-webpack-plugin/node_modules/schema-utils": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
+      "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.9",
+        "ajv": "^8.9.0",
+        "ajv-formats": "^2.1.1",
+        "ajv-keywords": "^5.1.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/@rollup/plugin-babel": {
@@ -3839,11 +3857,12 @@
       }
     },
     "node_modules/@tootallnate/once": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
-      "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-3.0.1.tgz",
+      "integrity": "sha512-VyMVKRrpHTT8PnotUeV8L/mDaMwD5DaAKCFLP73zAqAtvF0FCqky+Ki7BYbFCYQmqFyTe9316Ed5zS70QUR9eg==",
+      "license": "MIT",
       "engines": {
-        "node": ">= 6"
+        "node": ">= 10"
       }
     },
     "node_modules/@types/babel__core": {
@@ -4695,6 +4714,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-html": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.9.tgz",
+      "integrity": "sha512-ozbS3LuenHVxNRh/wdnN16QapUHzauqSomAl1jwwJRRsGwFwtj644lIhxfWu0Fy0acCij2+AEgHvjscq3dlVXg==",
+      "engines": [
+        "node >= 0.8.0"
+      ],
+      "license": "Apache-2.0",
+      "bin": {
+        "ansi-html": "bin/ansi-html"
       }
     },
     "node_modules/ansi-html-community": {
@@ -5886,11 +5917,6 @@
       "engines": {
         "node": ">= 10"
       }
-    },
-    "node_modules/common-path-prefix": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/common-path-prefix/-/common-path-prefix-3.0.0.tgz",
-      "integrity": "sha512-QE33hToZseCH3jS0qN96O/bSh3kaw/h+Tq7ngyY9eWDUnTlTNUyqfqvCXioLe5Na5jFsL78ra/wuBU4iuEgd4w=="
     },
     "node_modules/common-tags": {
       "version": "1.8.2",

--- a/2_Errors_Review/frontend/package.json
+++ b/2_Errors_Review/frontend/package.json
@@ -35,6 +35,7 @@
     "nth-check": "^2.1.1",
     "serialize-javascript": "^7.0.3",
     "underscore": "^1.13.8",
-    "webpack-dev-server": "^5.2.5"
+    "webpack-dev-server": "^5.2.5",
+    "@tootallnate/once": "^3.0.1"
   }
 }

--- a/2_Errors_Starter/backend/requirements.txt
+++ b/2_Errors_Starter/backend/requirements.txt
@@ -1,11 +1,11 @@
 aniso8601==6.0.0
 Click==7.0
 Flask==2.2.5
-Flask-Cors==5.0.0
+Flask-Cors==6.0.0
 Flask-RESTful==0.3.7
 Flask-SQLAlchemy==2.4.0
 itsdangerous==1.1.0
-Jinja2==3.1.5
+Jinja2==3.1.6
 MarkupSafe==1.1.1
 psycopg2-binary==2.8.2
 pytz==2019.1

--- a/2_Errors_Starter/frontend/package-lock.json
+++ b/2_Errors_Starter/frontend/package-lock.json
@@ -3638,9 +3638,10 @@
       }
     },
     "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
-      "version": "0.5.15",
-      "resolved": "https://registry.npmjs.org/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.15.tgz",
-      "integrity": "sha512-LFWllMA55pzB9D34w/wXUCf8+c+IYKuJDgxiZ3qMhl64KRMBHYM1I3VdGaD2BV5FNPV2/S2596bppxHbv2ZydQ==",
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.17.tgz",
+      "integrity": "sha512-tXDyE1/jzFsHXjhRZQ3hMl0IVhYe5qula43LDWIhVfjp9G/nT5OQY5AORVOrkEGAUltBJOfOWeETbmhm6kHhuQ==",
+      "license": "MIT",
       "dependencies": {
         "ansi-html": "^0.0.9",
         "core-js-pure": "^3.23.3",
@@ -4008,11 +4009,12 @@
       }
     },
     "node_modules/@tootallnate/once": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
-      "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-3.0.1.tgz",
+      "integrity": "sha512-VyMVKRrpHTT8PnotUeV8L/mDaMwD5DaAKCFLP73zAqAtvF0FCqky+Ki7BYbFCYQmqFyTe9316Ed5zS70QUR9eg==",
+      "license": "MIT",
       "engines": {
-        "node": ">= 6"
+        "node": ">= 10"
       }
     },
     "node_modules/@types/babel__core": {

--- a/2_Errors_Starter/frontend/package.json
+++ b/2_Errors_Starter/frontend/package.json
@@ -35,6 +35,7 @@
     "nth-check": "^2.1.1",
     "serialize-javascript": "^7.0.3",
     "underscore": "^1.13.8",
-    "webpack-dev-server": "^5.2.5"
+    "webpack-dev-server": "^5.2.5",
+    "@tootallnate/once": "^3.0.1"
   }
 }

--- a/3_Testing_Review/frontend/package-lock.json
+++ b/3_Testing_Review/frontend/package-lock.json
@@ -3334,18 +3334,17 @@
       "license": "0BSD"
     },
     "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
-      "version": "0.5.10",
-      "resolved": "https://registry.npmjs.org/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.10.tgz",
-      "integrity": "sha512-j0Ya0hCFZPd4x40qLzbhGsh9TMtdb+CJQiso+WxLOPNasohq9cc5SNUcwsZaRH6++Xh91Xkm/xHCkuIiIu0LUA==",
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.17.tgz",
+      "integrity": "sha512-tXDyE1/jzFsHXjhRZQ3hMl0IVhYe5qula43LDWIhVfjp9G/nT5OQY5AORVOrkEGAUltBJOfOWeETbmhm6kHhuQ==",
+      "license": "MIT",
       "dependencies": {
-        "ansi-html-community": "^0.0.8",
-        "common-path-prefix": "^3.0.0",
+        "ansi-html": "^0.0.9",
         "core-js-pure": "^3.23.3",
         "error-stack-parser": "^2.0.6",
-        "find-up": "^5.0.0",
         "html-entities": "^2.1.0",
         "loader-utils": "^2.0.4",
-        "schema-utils": "^3.0.0",
+        "schema-utils": "^4.2.0",
         "source-map": "^0.7.3"
       },
       "engines": {
@@ -3355,9 +3354,9 @@
         "@types/webpack": "4.x || 5.x",
         "react-refresh": ">=0.10.0 <1.0.0",
         "sockjs-client": "^1.4.0",
-        "type-fest": ">=0.17.0 <4.0.0",
+        "type-fest": ">=0.17.0 <5.0.0",
         "webpack": ">=4.43.0 <6.0.0",
-        "webpack-dev-server": "3.x || 4.x",
+        "webpack-dev-server": "3.x || 4.x || 5.x",
         "webpack-hot-middleware": "2.x",
         "webpack-plugin-serve": "0.x || 1.x"
       },
@@ -3380,6 +3379,25 @@
         "webpack-plugin-serve": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@pmmmwh/react-refresh-webpack-plugin/node_modules/schema-utils": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
+      "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.9",
+        "ajv": "^8.9.0",
+        "ajv-formats": "^2.1.1",
+        "ajv-keywords": "^5.1.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/@rollup/plugin-babel": {
@@ -3707,11 +3725,12 @@
       }
     },
     "node_modules/@tootallnate/once": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
-      "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-3.0.1.tgz",
+      "integrity": "sha512-VyMVKRrpHTT8PnotUeV8L/mDaMwD5DaAKCFLP73zAqAtvF0FCqky+Ki7BYbFCYQmqFyTe9316Ed5zS70QUR9eg==",
+      "license": "MIT",
       "engines": {
-        "node": ">= 6"
+        "node": ">= 10"
       }
     },
     "node_modules/@types/babel__core": {
@@ -4566,6 +4585,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-html": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.9.tgz",
+      "integrity": "sha512-ozbS3LuenHVxNRh/wdnN16QapUHzauqSomAl1jwwJRRsGwFwtj644lIhxfWu0Fy0acCij2+AEgHvjscq3dlVXg==",
+      "engines": [
+        "node >= 0.8.0"
+      ],
+      "license": "Apache-2.0",
+      "bin": {
+        "ansi-html": "bin/ansi-html"
       }
     },
     "node_modules/ansi-html-community": {
@@ -5740,11 +5771,6 @@
       "engines": {
         "node": ">= 10"
       }
-    },
-    "node_modules/common-path-prefix": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/common-path-prefix/-/common-path-prefix-3.0.0.tgz",
-      "integrity": "sha512-QE33hToZseCH3jS0qN96O/bSh3kaw/h+Tq7ngyY9eWDUnTlTNUyqfqvCXioLe5Na5jFsL78ra/wuBU4iuEgd4w=="
     },
     "node_modules/common-tags": {
       "version": "1.8.2",

--- a/3_Testing_Review/frontend/package.json
+++ b/3_Testing_Review/frontend/package.json
@@ -35,6 +35,7 @@
     "nth-check": "^2.1.1",
     "serialize-javascript": "^7.0.3",
     "underscore": "^1.13.8",
-    "webpack-dev-server": "^5.2.5"
+    "webpack-dev-server": "^5.2.5",
+    "@tootallnate/once": "^3.0.1"
   }
 }

--- a/3_Testing_Starter/frontend/package-lock.json
+++ b/3_Testing_Starter/frontend/package-lock.json
@@ -3334,18 +3334,17 @@
       "license": "0BSD"
     },
     "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
-      "version": "0.5.10",
-      "resolved": "https://registry.npmjs.org/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.10.tgz",
-      "integrity": "sha512-j0Ya0hCFZPd4x40qLzbhGsh9TMtdb+CJQiso+WxLOPNasohq9cc5SNUcwsZaRH6++Xh91Xkm/xHCkuIiIu0LUA==",
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.17.tgz",
+      "integrity": "sha512-tXDyE1/jzFsHXjhRZQ3hMl0IVhYe5qula43LDWIhVfjp9G/nT5OQY5AORVOrkEGAUltBJOfOWeETbmhm6kHhuQ==",
+      "license": "MIT",
       "dependencies": {
-        "ansi-html-community": "^0.0.8",
-        "common-path-prefix": "^3.0.0",
+        "ansi-html": "^0.0.9",
         "core-js-pure": "^3.23.3",
         "error-stack-parser": "^2.0.6",
-        "find-up": "^5.0.0",
         "html-entities": "^2.1.0",
         "loader-utils": "^2.0.4",
-        "schema-utils": "^3.0.0",
+        "schema-utils": "^4.2.0",
         "source-map": "^0.7.3"
       },
       "engines": {
@@ -3355,9 +3354,9 @@
         "@types/webpack": "4.x || 5.x",
         "react-refresh": ">=0.10.0 <1.0.0",
         "sockjs-client": "^1.4.0",
-        "type-fest": ">=0.17.0 <4.0.0",
+        "type-fest": ">=0.17.0 <5.0.0",
         "webpack": ">=4.43.0 <6.0.0",
-        "webpack-dev-server": "3.x || 4.x",
+        "webpack-dev-server": "3.x || 4.x || 5.x",
         "webpack-hot-middleware": "2.x",
         "webpack-plugin-serve": "0.x || 1.x"
       },
@@ -3380,6 +3379,25 @@
         "webpack-plugin-serve": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@pmmmwh/react-refresh-webpack-plugin/node_modules/schema-utils": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
+      "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.9",
+        "ajv": "^8.9.0",
+        "ajv-formats": "^2.1.1",
+        "ajv-keywords": "^5.1.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/@rollup/plugin-babel": {
@@ -3707,11 +3725,12 @@
       }
     },
     "node_modules/@tootallnate/once": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
-      "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-3.0.1.tgz",
+      "integrity": "sha512-VyMVKRrpHTT8PnotUeV8L/mDaMwD5DaAKCFLP73zAqAtvF0FCqky+Ki7BYbFCYQmqFyTe9316Ed5zS70QUR9eg==",
+      "license": "MIT",
       "engines": {
-        "node": ">= 6"
+        "node": ">= 10"
       }
     },
     "node_modules/@types/babel__core": {
@@ -4566,6 +4585,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-html": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.9.tgz",
+      "integrity": "sha512-ozbS3LuenHVxNRh/wdnN16QapUHzauqSomAl1jwwJRRsGwFwtj644lIhxfWu0Fy0acCij2+AEgHvjscq3dlVXg==",
+      "engines": [
+        "node >= 0.8.0"
+      ],
+      "license": "Apache-2.0",
+      "bin": {
+        "ansi-html": "bin/ansi-html"
       }
     },
     "node_modules/ansi-html-community": {
@@ -5740,11 +5771,6 @@
       "engines": {
         "node": ">= 10"
       }
-    },
-    "node_modules/common-path-prefix": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/common-path-prefix/-/common-path-prefix-3.0.0.tgz",
-      "integrity": "sha512-QE33hToZseCH3jS0qN96O/bSh3kaw/h+Tq7ngyY9eWDUnTlTNUyqfqvCXioLe5Na5jFsL78ra/wuBU4iuEgd4w=="
     },
     "node_modules/common-tags": {
       "version": "1.8.2",

--- a/3_Testing_Starter/frontend/package.json
+++ b/3_Testing_Starter/frontend/package.json
@@ -35,6 +35,7 @@
     "nth-check": "^2.1.1",
     "serialize-javascript": "^7.0.3",
     "underscore": "^1.13.8",
-    "webpack-dev-server": "^5.2.5"
+    "webpack-dev-server": "^5.2.5",
+    "@tootallnate/once": "^3.0.1"
   }
 }

--- a/4_TDD_Review/backend/requirements.txt
+++ b/4_TDD_Review/backend/requirements.txt
@@ -1,11 +1,11 @@
 aniso8601==6.0.0
 Click==7.0
 Flask==2.2.5
-Flask-Cors==5.0.0
+Flask-Cors==6.0.0
 Flask-RESTful==0.3.7
 Flask-SQLAlchemy==2.4.0
 itsdangerous==1.1.0
-Jinja2==3.1.5
+Jinja2==3.1.6
 MarkupSafe==1.1.1
 psycopg2-binary==2.8.2
 pytz==2019.1

--- a/4_TDD_Review/frontend/package-lock.json
+++ b/4_TDD_Review/frontend/package-lock.json
@@ -3334,18 +3334,17 @@
       "license": "0BSD"
     },
     "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
-      "version": "0.5.10",
-      "resolved": "https://registry.npmjs.org/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.10.tgz",
-      "integrity": "sha512-j0Ya0hCFZPd4x40qLzbhGsh9TMtdb+CJQiso+WxLOPNasohq9cc5SNUcwsZaRH6++Xh91Xkm/xHCkuIiIu0LUA==",
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.17.tgz",
+      "integrity": "sha512-tXDyE1/jzFsHXjhRZQ3hMl0IVhYe5qula43LDWIhVfjp9G/nT5OQY5AORVOrkEGAUltBJOfOWeETbmhm6kHhuQ==",
+      "license": "MIT",
       "dependencies": {
-        "ansi-html-community": "^0.0.8",
-        "common-path-prefix": "^3.0.0",
+        "ansi-html": "^0.0.9",
         "core-js-pure": "^3.23.3",
         "error-stack-parser": "^2.0.6",
-        "find-up": "^5.0.0",
         "html-entities": "^2.1.0",
         "loader-utils": "^2.0.4",
-        "schema-utils": "^3.0.0",
+        "schema-utils": "^4.2.0",
         "source-map": "^0.7.3"
       },
       "engines": {
@@ -3355,9 +3354,9 @@
         "@types/webpack": "4.x || 5.x",
         "react-refresh": ">=0.10.0 <1.0.0",
         "sockjs-client": "^1.4.0",
-        "type-fest": ">=0.17.0 <4.0.0",
+        "type-fest": ">=0.17.0 <5.0.0",
         "webpack": ">=4.43.0 <6.0.0",
-        "webpack-dev-server": "3.x || 4.x",
+        "webpack-dev-server": "3.x || 4.x || 5.x",
         "webpack-hot-middleware": "2.x",
         "webpack-plugin-serve": "0.x || 1.x"
       },
@@ -3380,6 +3379,25 @@
         "webpack-plugin-serve": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@pmmmwh/react-refresh-webpack-plugin/node_modules/schema-utils": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
+      "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.9",
+        "ajv": "^8.9.0",
+        "ajv-formats": "^2.1.1",
+        "ajv-keywords": "^5.1.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/@rollup/plugin-babel": {
@@ -3707,11 +3725,12 @@
       }
     },
     "node_modules/@tootallnate/once": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
-      "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-3.0.1.tgz",
+      "integrity": "sha512-VyMVKRrpHTT8PnotUeV8L/mDaMwD5DaAKCFLP73zAqAtvF0FCqky+Ki7BYbFCYQmqFyTe9316Ed5zS70QUR9eg==",
+      "license": "MIT",
       "engines": {
-        "node": ">= 6"
+        "node": ">= 10"
       }
     },
     "node_modules/@types/babel__core": {
@@ -4566,6 +4585,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-html": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.9.tgz",
+      "integrity": "sha512-ozbS3LuenHVxNRh/wdnN16QapUHzauqSomAl1jwwJRRsGwFwtj644lIhxfWu0Fy0acCij2+AEgHvjscq3dlVXg==",
+      "engines": [
+        "node >= 0.8.0"
+      ],
+      "license": "Apache-2.0",
+      "bin": {
+        "ansi-html": "bin/ansi-html"
       }
     },
     "node_modules/ansi-html-community": {
@@ -5740,11 +5771,6 @@
       "engines": {
         "node": ">= 10"
       }
-    },
-    "node_modules/common-path-prefix": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/common-path-prefix/-/common-path-prefix-3.0.0.tgz",
-      "integrity": "sha512-QE33hToZseCH3jS0qN96O/bSh3kaw/h+Tq7ngyY9eWDUnTlTNUyqfqvCXioLe5Na5jFsL78ra/wuBU4iuEgd4w=="
     },
     "node_modules/common-tags": {
       "version": "1.8.2",

--- a/4_TDD_Review/frontend/package.json
+++ b/4_TDD_Review/frontend/package.json
@@ -35,6 +35,7 @@
     "nth-check": "^2.1.1",
     "serialize-javascript": "^7.0.3",
     "underscore": "^1.13.8",
-    "webpack-dev-server": "^5.2.5"
+    "webpack-dev-server": "^5.2.5",
+    "@tootallnate/once": "^3.0.1"
   }
 }

--- a/4_TDD_Starter/backend/requirements.txt
+++ b/4_TDD_Starter/backend/requirements.txt
@@ -1,11 +1,11 @@
 aniso8601==6.0.0
 Click==7.0
 Flask==2.2.5
-Flask-Cors==5.0.0
+Flask-Cors==6.0.0
 Flask-RESTful==0.3.7
 Flask-SQLAlchemy==2.4.0
 itsdangerous==1.1.0
-Jinja2==3.1.5
+Jinja2==3.1.6
 MarkupSafe==1.1.1
 psycopg2-binary==2.8.2
 pytz==2019.1

--- a/5_API_Doc_Review/backend/requirements.txt
+++ b/5_API_Doc_Review/backend/requirements.txt
@@ -1,11 +1,11 @@
 aniso8601==6.0.0
 Click==7.0
 Flask==2.2.5
-Flask-Cors==5.0.0
+Flask-Cors==6.0.0
 Flask-RESTful==0.3.7
 Flask-SQLAlchemy==2.4.0
 itsdangerous==1.1.0
-Jinja2==3.1.5
+Jinja2==3.1.6
 MarkupSafe==1.1.1
 psycopg2-binary==2.8.2
 pytz==2019.1

--- a/5_API_Doc_Starter/backend/requirements.txt
+++ b/5_API_Doc_Starter/backend/requirements.txt
@@ -1,11 +1,11 @@
 aniso8601==6.0.0
 Click==7.0
 Flask==2.2.5
-Flask-Cors==5.0.0
+Flask-Cors==6.0.0
 Flask-RESTful==0.3.7
 Flask-SQLAlchemy==2.4.0
 itsdangerous==1.1.0
-Jinja2==3.1.5
+Jinja2==3.1.6
 MarkupSafe==1.1.1
 psycopg2-binary==2.8.2
 pytz==2019.1

--- a/6_Final_Review/backend/requirements.txt
+++ b/6_Final_Review/backend/requirements.txt
@@ -1,11 +1,11 @@
 aniso8601==6.0.0
 Click==7.0
 Flask==2.2.5
-Flask-Cors==5.0.0
+Flask-Cors==6.0.0
 Flask-RESTful==0.3.7
 Flask-SQLAlchemy==2.4.0
 itsdangerous==1.1.0
-Jinja2==3.1.5
+Jinja2==3.1.6
 MarkupSafe==1.1.1
 psycopg2-binary==2.8.2
 pytz==2019.1

--- a/6_Final_Starter/backend/requirements.txt
+++ b/6_Final_Starter/backend/requirements.txt
@@ -1,11 +1,11 @@
 aniso8601==6.0.0
 Click==7.0
 Flask==2.2.5
-Flask-Cors==5.0.0
+Flask-Cors==6.0.0
 Flask-RESTful==0.3.7
 Flask-SQLAlchemy==2.4.0
 itsdangerous==1.1.0
-Jinja2==3.1.5
+Jinja2==3.1.6
 MarkupSafe==1.1.1
 psycopg2-binary==2.8.2
 pytz==2019.1


### PR DESCRIPTION
## Summary

Fixes all moderate and low Dependabot vulnerabilities that can be resolved without a breaking framework migration.

## Vulnerability Summary

| Package | Old | New | Severity | Method | Status |
|---|---|---|---|---|---|
| Jinja2 (GHSA-cpwx-vrp4-4pq7) | 3.1.5 | 3.1.6 | Medium | Pin bump | ✅ Fixed |
| Flask-Cors (GHSA-rrx3-fwrm-g7r4 + 2 more) | 5.0.0 | 6.0.0 | Medium | Pin bump | ✅ Fixed |
| @tootallnate/once (GHSA-h8cv-xqh8-f3q9) | 1.1.2 | 3.0.1 | Low | Override | ✅ Fixed |
| Flask (Vary: Cookie) | 2.2.5 | — | Low | — | ⛔ Blocked |
| uuid (buffer bounds check) | 8.3.2 | — | Medium | — | ⛔ Blocked |
| postcss (XSS + line return) | 7.0.39 | — | Medium | — | ⛔ Blocked |
| js-yaml (ReDoS) | 3.15.0 | — | Medium | — | ⛔ Blocked |

## Python — 8 backends (`requirements.txt`)

**Jinja2 3.1.5 → 3.1.6** (7 backends — `2_Errors_Starter`, `4_TDD_*`, `5_API_Doc_*`, `6_Final_*`)
Minor patch bump. `1_Requests_Starter` already uses the open range `jinja2>=2.11.3`.

**Flask-Cors 5.0.0 → 6.0.0** (all 8 backends)
Fixes improper regex path-matching that could allow unintended CORS origins. Flask-Cors 6.x requires `flask>=0.9` — fully compatible with the current `Flask==2.2.5` stack.

## JavaScript — 7 frontends (`package.json` + `package-lock.json`)

**@tootallnate/once 1.1.2 → 3.0.1** via `"overrides": {"@tootallnate/once": "^3.0.1"}`
The CVE's affected range is `>= 3.0.0, < 3.0.1`. The currently installed version (1.1.2) is technically outside the affected range, but Dependabot flags it and the override brings it to the patched version. `http-proxy-agent@4.0.1` is API-compatible with @tootallnate/once v3.x.

`npm audit fix --package-lock-only` was also run, which additionally bumped `@pmmmwh/react-refresh-webpack-plugin` (0.5.10 → 0.5.17) and `ansi-html` (→ 0.0.9).

## Blocked vulnerabilities — require framework migration

### Flask (low) `< 3.1.3` — missing `Vary: Cookie` header
Requires Flask 3.x, which is a **major breaking change** for the entire Python stack:
- `Flask-SQLAlchemy 2.4.0` → needs 3.x (different model init and config API)
- `Flask-RESTful 0.3.7` → needs patching for Flask 3.x compatibility
- Application code changes required for deprecated Flask 2.x patterns

### uuid / postcss / js-yaml (medium) — locked in `react-scripts@5.0.1`

All three are buried inside the abandoned Create React App toolchain:
- `uuid@8.3.2` via `sockjs` (used by webpack-dev-server)
- `postcss@7.0.39` via `resolve-url-loader` (no 7.x fix exists; fixed in 8.4.31+)
- `js-yaml@3.15.0` via `svgo@1.x` (fix only in 4.x, backport not available)

**Fix requires migrating from CRA to Vite** (or another maintained bundler). CRA has not been updated since April 2022.

🤖 Generated with [Claude Code](https://claude.com/claude-code)